### PR TITLE
Fix alignment issue in GuessDistribution

### DIFF
--- a/src/GuessDistribution.tsx
+++ b/src/GuessDistribution.tsx
@@ -6,7 +6,7 @@ function GuessDistribution({ distribution, userResult, isWon }: { distribution: 
     <Box sx={{ width: '80%', display: 'flex', flexDirection: 'column', alignContent: 'center', justifyContent: 'center', alignItems: 'flex-start', gap: '0.5rem 0', userSelect: 'none' }}>
       {distribution.map((g, i) => (
         <Box key={i} sx={{ display: 'flex', gap: '0 1rem', width: '100%' }}>
-          <Typography variant="body1" sx={{ fontWeight: 800, fontFamily: 'monospaced' }}>{i + 1}</Typography>
+          <Typography variant="body1" sx={{ fontWeight: 800, fontFamily: 'monospace' }}>{i + 1}</Typography>
           <Box
             sx={{
               flex: `0 1 0%`,
@@ -23,7 +23,7 @@ function GuessDistribution({ distribution, userResult, isWon }: { distribution: 
                 }
               }
             }}>
-            <Typography variant="body1" sx={{ lineHeight: '1rem', color: 'white', fontWeight: 700, fontFamily: 'monospaced', height: 'fit-content', margin: '0.2rem 0.5rem' }}>
+            <Typography variant="body1" sx={{ lineHeight: '1rem', color: 'white', fontWeight: 700, fontFamily: 'monospace', height: 'fit-content', margin: '0.2rem 0.5rem' }}>
               {g}
             </Typography>
           </Box>


### PR DESCRIPTION
# Justification
After a game ends we get a summary modal displayed to us about our personal best results. This modal is misaligned which makes me sad. We should fix this somehow.

Here's an example on how the issue looks on desktop, the bars are not aligned:
<img width="774" height="783" alt="image" src="https://github.com/user-attachments/assets/537ed186-235b-4b5d-8b3c-41ff964332aa" />

# Implementation
We can resolve this in multiple ways but the easiest would be to set the `font-family` attribute to `monospace`, we could also switch to a `grid` layout but that would be a reasonable amount of change.

# Testing
Since I'm not a frontend guy, I just colored the appropriate elements to have a reasonable way to compare the new layout with the old one lol. I used Firefox for testing the changes, I also validated the changes in the mobile view mode.

## Desktop
<img width="1732" height="689" alt="desktop_geodle" src="https://github.com/user-attachments/assets/4ed97834-961e-4ffb-a9c7-d24802e556d2" />

## Mobile
<img width="1734" height="658" alt="mobile_geodle" src="https://github.com/user-attachments/assets/fccb52dc-fc66-46a0-a8a2-f94c419aca77" />

## Without the custom markers I used for debugging
<img width="1729" height="634" alt="image" src="https://github.com/user-attachments/assets/0953d52e-6135-4ad8-a416-1979a675fea7" />

## On mobile, without the custom markers I used for debugging
<img width="1554" height="626" alt="image" src="https://github.com/user-attachments/assets/3eb9cb0c-c30b-4efa-b92b-60b33378f7f7" />
